### PR TITLE
📋 doc(BrandsReport/IndustryReport): add `brands_with_websites_by_date`

### DIFF
--- a/source/includes/api.html.md.erb
+++ b/source/includes/api.html.md.erb
@@ -8907,6 +8907,280 @@ Para realizar esta operación es obligatorio utilizar tu <strong><a href="#confi
       <span class="param__desc">Fecha en formato de milisegundos</span>
     </li>
     
+    <li class="param__child2 ">
+      <strong class="param__name">
+        
+          
+<button class="param__toggle">►</button>
+
+        
+        brands_with_websites_by_date
+      </strong>
+      <small class="param__type">array</small>
+      <br />
+      <span class="param__desc">Marcas con sitios web por fecha</span>
+    </li>
+    
+    <li class="param__child3 param__hidden">
+      <strong class="param__name">
+        
+        id
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Identificador del objeto</span>
+    </li>
+    
+    <li class="param__child3 param__hidden">
+      <strong class="param__name">
+        
+        name
+      </strong>
+      <small class="param__type">string</small>
+      <br />
+      <span class="param__desc">Nombre del objeto</span>
+    </li>
+    
+    <li class="param__child3 param__hidden">
+      <strong class="param__name">
+        
+        metrics
+      </strong>
+      <small class="param__type">object</small>
+      <br />
+      <span class="param__desc">Métricas del objeto</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        count
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        impact
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Número de impactos</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        impressions
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Número de impresiones</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        valuation
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Valorización en moneda local</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        valuation_by_country
+      </strong>
+      <small class="param__type">array</small>
+      <br />
+      <span class="param__desc">Valorización por país</span>
+    </li>
+    
+    <li class="param__child5 param__hidden">
+      <strong class="param__name">
+        
+        country
+      </strong>
+      <small class="param__type">string</small>
+      <br />
+      <span class="param__desc">País valorizado</span>
+    </li>
+    
+    <li class="param__child5 param__hidden">
+      <strong class="param__name">
+        
+        value
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Valorización del país</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        valuation_usd
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Valorización en dólares</span>
+    </li>
+    
+    <li class="param__child3 param__hidden">
+      <strong class="param__name">
+        
+        websites_by_date
+      </strong>
+      <small class="param__type">array</small>
+      <br />
+      <span class="param__desc">Métricas por sitios web por fecha</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        id
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Identificador del sitio web</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        domain
+      </strong>
+      <small class="param__type">string</small>
+      <br />
+      <span class="param__desc">Dominio del sitio web</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        metrics_by_date
+      </strong>
+      <small class="param__type">array</small>
+      <br />
+      <span class="param__desc">Métricas por fecha</span>
+    </li>
+    
+    <li class="param__child5 param__hidden">
+      <strong class="param__name">
+        
+        date
+      </strong>
+      <small class="param__type">string</small>
+      <br />
+      <span class="param__desc">Fecha en formato YYYY-MM-DD</span>
+    </li>
+    
+    <li class="param__child5 param__hidden">
+      <strong class="param__name">
+        
+        metrics
+      </strong>
+      <small class="param__type">object</small>
+      <br />
+      <span class="param__desc">Métricas encontradas</span>
+    </li>
+    
+    <li class="param__child6 param__hidden">
+      <strong class="param__name">
+        
+        count
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      
+    </li>
+    
+    <li class="param__child6 param__hidden">
+      <strong class="param__name">
+        
+        impact
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Número de impactos</span>
+    </li>
+    
+    <li class="param__child6 param__hidden">
+      <strong class="param__name">
+        
+        impressions
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Número de impresiones</span>
+    </li>
+    
+    <li class="param__child6 param__hidden">
+      <strong class="param__name">
+        
+        valuation
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Valorización en moneda local</span>
+    </li>
+    
+    <li class="param__child6 param__hidden">
+      <strong class="param__name">
+        
+        valuation_by_country
+      </strong>
+      <small class="param__type">array</small>
+      <br />
+      <span class="param__desc">Valorización por país</span>
+    </li>
+    
+    <li class="param__child7 param__hidden">
+      <strong class="param__name">
+        
+        country
+      </strong>
+      <small class="param__type">string</small>
+      <br />
+      <span class="param__desc">País valorizado</span>
+    </li>
+    
+    <li class="param__child7 param__hidden">
+      <strong class="param__name">
+        
+        value
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Valorización del país</span>
+    </li>
+    
+    <li class="param__child6 param__hidden">
+      <strong class="param__name">
+        
+        valuation_usd
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Valorización en dólares</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        date_int
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Fecha en formato de milisegundos</span>
+    </li>
+    
     <li class="param__child1 ">
       <strong class="param__name">
         
@@ -15293,6 +15567,280 @@ Para realizar esta operación es obligatorio utilizar tu <strong><a href="#confi
     </li>
     
     <li class="param__child3 param__hidden">
+      <strong class="param__name">
+        
+        date_int
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Fecha en formato de milisegundos</span>
+    </li>
+    
+    <li class="param__child2 ">
+      <strong class="param__name">
+        
+          
+<button class="param__toggle">►</button>
+
+        
+        brands_with_websites_by_date
+      </strong>
+      <small class="param__type">array</small>
+      <br />
+      <span class="param__desc">Marcas con sitios web por fecha</span>
+    </li>
+    
+    <li class="param__child3 param__hidden">
+      <strong class="param__name">
+        
+        id
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Identificador del objeto</span>
+    </li>
+    
+    <li class="param__child3 param__hidden">
+      <strong class="param__name">
+        
+        name
+      </strong>
+      <small class="param__type">string</small>
+      <br />
+      <span class="param__desc">Nombre del objeto</span>
+    </li>
+    
+    <li class="param__child3 param__hidden">
+      <strong class="param__name">
+        
+        metrics
+      </strong>
+      <small class="param__type">object</small>
+      <br />
+      <span class="param__desc">Métricas del objeto</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        count
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        impact
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Número de impactos</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        impressions
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Número de impresiones</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        valuation
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Valorización en moneda local</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        valuation_by_country
+      </strong>
+      <small class="param__type">array</small>
+      <br />
+      <span class="param__desc">Valorización por país</span>
+    </li>
+    
+    <li class="param__child5 param__hidden">
+      <strong class="param__name">
+        
+        country
+      </strong>
+      <small class="param__type">string</small>
+      <br />
+      <span class="param__desc">País valorizado</span>
+    </li>
+    
+    <li class="param__child5 param__hidden">
+      <strong class="param__name">
+        
+        value
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Valorización del país</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        valuation_usd
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Valorización en dólares</span>
+    </li>
+    
+    <li class="param__child3 param__hidden">
+      <strong class="param__name">
+        
+        websites_by_date
+      </strong>
+      <small class="param__type">array</small>
+      <br />
+      <span class="param__desc">Métricas por sitios web por fecha</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        id
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Identificador del sitio web</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        domain
+      </strong>
+      <small class="param__type">string</small>
+      <br />
+      <span class="param__desc">Dominio del sitio web</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
+      <strong class="param__name">
+        
+        metrics_by_date
+      </strong>
+      <small class="param__type">array</small>
+      <br />
+      <span class="param__desc">Métricas por fecha</span>
+    </li>
+    
+    <li class="param__child5 param__hidden">
+      <strong class="param__name">
+        
+        date
+      </strong>
+      <small class="param__type">string</small>
+      <br />
+      <span class="param__desc">Fecha en formato YYYY-MM-DD</span>
+    </li>
+    
+    <li class="param__child5 param__hidden">
+      <strong class="param__name">
+        
+        metrics
+      </strong>
+      <small class="param__type">object</small>
+      <br />
+      <span class="param__desc">Métricas encontradas</span>
+    </li>
+    
+    <li class="param__child6 param__hidden">
+      <strong class="param__name">
+        
+        count
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      
+    </li>
+    
+    <li class="param__child6 param__hidden">
+      <strong class="param__name">
+        
+        impact
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Número de impactos</span>
+    </li>
+    
+    <li class="param__child6 param__hidden">
+      <strong class="param__name">
+        
+        impressions
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Número de impresiones</span>
+    </li>
+    
+    <li class="param__child6 param__hidden">
+      <strong class="param__name">
+        
+        valuation
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Valorización en moneda local</span>
+    </li>
+    
+    <li class="param__child6 param__hidden">
+      <strong class="param__name">
+        
+        valuation_by_country
+      </strong>
+      <small class="param__type">array</small>
+      <br />
+      <span class="param__desc">Valorización por país</span>
+    </li>
+    
+    <li class="param__child7 param__hidden">
+      <strong class="param__name">
+        
+        country
+      </strong>
+      <small class="param__type">string</small>
+      <br />
+      <span class="param__desc">País valorizado</span>
+    </li>
+    
+    <li class="param__child7 param__hidden">
+      <strong class="param__name">
+        
+        value
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Valorización del país</span>
+    </li>
+    
+    <li class="param__child6 param__hidden">
+      <strong class="param__name">
+        
+        valuation_usd
+      </strong>
+      <small class="param__type">integer</small>
+      <br />
+      <span class="param__desc">Valorización en dólares</span>
+    </li>
+    
+    <li class="param__child4 param__hidden">
       <strong class="param__name">
         
         date_int

--- a/source/includes/snippets/_post-reporte-de-industria.md
+++ b/source/includes/snippets/_post-reporte-de-industria.md
@@ -100,23 +100,23 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
   "meta": {
     "date_range": {
       "start": "2020-11-23T11:06:44.000Z",
-      "end": "2020-11-23T11:06:44.000Z"
+      "end": "2020-11-24T00:48:55.000Z"
     }
   },
   "data": {
     "industries": [
       {
         "metrics": {
-          "impact": 8152,
-          "count": 1,
-          "valuation_usd": 54.44819822133432,
+          "impact": 8241,
+          "count": 4,
+          "valuation_usd": 55.02575678173888,
           "valuation_by_country": [
             {
-              "chile": 38163
+              "chile": 39050
             }
           ],
-          "impressions": 29387,
-          "valuation": 38163
+          "impressions": 30168,
+          "valuation": 39050
         },
         "id": 204,
         "name": "deportes y tiempo libre - artículos deportivos"
@@ -131,7 +131,7 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
             "metrics": {
               "impact": 8152,
               "count": 1,
-              "valuation_usd": 54.44819822133432,
+              "valuation_usd": 53.775875955480174,
               "valuation_by_country": [
                 {
                   "chile": 38163
@@ -144,21 +144,87 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
           }
         ],
         "id": 365
+      },
+      {
+        "domain": "diarioconcepcion.cl",
+        "metrics_by_date": [
+          {
+            "date": "2020-11-23T00:00:00.000Z",
+            "metrics": {
+              "impact": 62,
+              "count": 1,
+              "valuation_usd": 1.0779693710122982,
+              "valuation_by_country": [
+                {
+                  "chile": 765
+                }
+              ],
+              "impressions": 674,
+              "valuation": 765
+            },
+            "date_int": 1606089600000
+          }
+        ],
+        "id": 4250
+      },
+      {
+        "domain": "aplicaciones.info",
+        "metrics_by_date": [
+          {
+            "date": "2020-11-24T00:00:00.000Z",
+            "metrics": {
+              "impact": 22,
+              "count": 1,
+              "valuation_usd": 0.12681992600144684,
+              "valuation_by_country": [
+                {
+                  "chile": 90
+                }
+              ],
+              "impressions": 79,
+              "valuation": 90
+            },
+            "date_int": 1606176000000
+          }
+        ],
+        "id": 386
+      },
+      {
+        "domain": "bluradio.com",
+        "metrics_by_date": [
+          {
+            "date": "2020-11-24T00:00:00.000Z",
+            "metrics": {
+              "impact": 5,
+              "count": 1,
+              "valuation_usd": 0.04509152924495887,
+              "valuation_by_country": [
+                {
+                  "chile": 32
+                }
+              ],
+              "impressions": 28,
+              "valuation": 32
+            },
+            "date_int": 1606176000000
+          }
+        ],
+        "id": 1276
       }
     ],
     "ad_types": [
       {
         "metrics": {
-          "impact": 8152,
-          "count": 1,
-          "valuation_usd": 54.44819822133432,
+          "impact": 8241,
+          "count": 4,
+          "valuation_usd": 55.02575678173888,
           "valuation_by_country": [
             {
-              "chile": 38163
+              "chile": 39050
             }
           ],
-          "impressions": 29387,
-          "valuation": 38163
+          "impressions": 30168,
+          "valuation": 39050
         },
         "id": 1,
         "name": "display"
@@ -167,16 +233,16 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
     "countries": [
       {
         "metrics": {
-          "impact": 8152,
-          "count": 1,
-          "valuation_usd": 54.44819822133432,
+          "impact": 8241,
+          "count": 4,
+          "valuation_usd": 55.02575678173888,
           "valuation_by_country": [
             {
-              "chile": 38163
+              "chile": 39050
             }
           ],
-          "impressions": 29387,
-          "valuation": 38163
+          "impressions": 30168,
+          "valuation": 39050
         },
         "id": 1,
         "name": "chile"
@@ -184,21 +250,21 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
     ],
     "date_range": {
       "start": "2020-11-23T11:06:44.000Z",
-      "end": "2020-11-23T11:06:44.000Z"
+      "end": "2020-11-24T00:48:55.000Z"
     },
     "sold_by": [
       {
         "metrics": {
-          "impact": 8152,
-          "count": 1,
-          "valuation_usd": 54.44819822133432,
+          "impact": 8241,
+          "count": 4,
+          "valuation_usd": 55.02575678173888,
           "valuation_by_country": [
             {
-              "chile": 38163
+              "chile": 39050
             }
           ],
-          "impressions": 29387,
-          "valuation": 38163
+          "impressions": 30168,
+          "valuation": 39050
         },
         "id": "google",
         "name": "google"
@@ -207,16 +273,16 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
     "devices": [
       {
         "metrics": {
-          "impact": 8152,
-          "count": 1,
-          "valuation_usd": 54.44819822133432,
+          "impact": 8241,
+          "count": 4,
+          "valuation_usd": 55.02575678173888,
           "valuation_by_country": [
             {
-              "chile": 38163
+              "chile": 39050
             }
           ],
-          "impressions": 29387,
-          "valuation": 38163
+          "impressions": 30168,
+          "valuation": 39050
         },
         "id": 1,
         "name": "desktop"
@@ -227,21 +293,31 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
         {
           "date": "2020-11-23T00:00:00.000Z",
           "metrics": {
-            "impact": 8152,
-            "valuation_usd": 54.44819822133432,
-            "impressions": 29387,
-            "valuation": 38163
+            "impact": 8214,
+            "valuation_usd": 54.85384532649247,
+            "impressions": 30061,
+            "valuation": 38928
           },
           "date_int": 1606089600000
+        },
+        {
+          "date": "2020-11-24T00:00:00.000Z",
+          "metrics": {
+            "impact": 27,
+            "valuation_usd": 0.17191145524640572,
+            "impressions": 107,
+            "valuation": 122
+          },
+          "date_int": 1606176000000
         }
       ],
       "ad_types": [
         {
           "metrics": {
-            "impact": 8152,
-            "valuation_usd": 54.44819822133432,
-            "impressions": 29387,
-            "valuation": 38163
+            "impact": 8241,
+            "valuation_usd": 55.02575678173888,
+            "impressions": 30168,
+            "valuation": 39050
           },
           "id": 1,
           "name": "display"
@@ -250,36 +326,36 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
       "countries": [
         {
           "metrics": {
-            "impact": 8152,
-            "valuation_usd": 54.44819822133432,
-            "impressions": 29387,
-            "valuation": 38163
+            "impact": 8241,
+            "valuation_usd": 55.02575678173888,
+            "impressions": 30168,
+            "valuation": 39050
           },
           "id": 1,
           "name": "chile"
         }
       ],
-      "total_impressions": 29387,
-      "total_impact": 8152,
+      "total_impressions": 30168,
+      "total_impact": 8241,
       "devices": [
         {
           "metrics": {
-            "impact": 8152,
-            "valuation_usd": 54.44819822133432,
-            "impressions": 29387,
-            "valuation": 38163
+            "impact": 8241,
+            "valuation_usd": 55.02575678173888,
+            "impressions": 30168,
+            "valuation": 39050
           },
           "id": 1,
           "name": "desktop"
         }
       ],
-      "total_valuation_usd": 54.44819822133432,
+      "total_valuation_usd": 55.02575678173888,
       "position": {
-        "first_scroll": 0.0,
-        "second_scroll": 0.0,
-        "third_or_more_scroll": 1.0
+        "first_scroll": 0,
+        "second_scroll": 0.75,
+        "third_or_more_scroll": 0.25
       },
-      "total_valuation": 38163
+      "total_valuation": 39050
     },
     "campaigns": [
       {
@@ -307,7 +383,7 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
             "metrics": {
               "impact": 8152,
               "count": 1,
-              "valuation_usd": 54.44819822133432,
+              "valuation_usd": 53.775875955480174,
               "valuation_by_country": [
                 {
                   "chile": 38163
@@ -325,7 +401,7 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
             "metrics": {
               "impact": 8152,
               "count": 1,
-              "valuation_usd": 54.44819822133432,
+              "valuation_usd": 53.775875955480174,
               "valuation_by_country": [
                 {
                   "chile": 38163
@@ -341,7 +417,7 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
         "metrics": {
           "impact": 8152,
           "count": 1,
-          "valuation_usd": 54.44819822133432,
+          "valuation_usd": 53.775875955480174,
           "valuation_by_country": [
             {
               "chile": 38163
@@ -355,7 +431,7 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
             "metrics": {
               "impact": 8152,
               "count": 1,
-              "valuation_usd": 54.44819822133432,
+              "valuation_usd": 53.775875955480174,
               "valuation_by_country": [
                 {
                   "chile": 38163
@@ -373,7 +449,7 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
             "metrics": {
               "impact": 8152,
               "count": 1,
-              "valuation_usd": 54.44819822133432,
+              "valuation_usd": 53.775875955480174,
               "valuation_by_country": [
                 {
                   "chile": 38163
@@ -401,7 +477,7 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
             "metrics": {
               "impact": 8152,
               "count": 1,
-              "valuation_usd": 54.44819822133432,
+              "valuation_usd": 53.775875955480174,
               "valuation_by_country": [
                 {
                   "chile": 38163
@@ -414,6 +490,272 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
             "name": "display"
           }
         ]
+      },
+      {
+        "landing_page": "dirtbrothers.cl/products/zapatilla-dc-shoes-hombre-dc-infinite-m-shoe-b",
+        "description": "amarillo | blanco | engranaje deportes | equipo protección personal | guante | guante bateo | guante bicicleta | guante seguridad | ropa | ropa deporte",
+        "ad_format": {
+          "id": 154,
+          "name": "brand-day"
+        },
+        "title": "Zapatilla DC Shoes Hombre DC INFINITE M SHOE B– Dirt Brothers",
+        "date_range": {
+          "start": "2020-11-23T17:20:52.000Z",
+          "end": "2020-11-23T17:20:52.000Z"
+        },
+        "industry": {
+          "id": 204,
+          "name": "deportes y tiempo libre - artículos deportivos"
+        },
+        "brand": {
+          "id": 342746,
+          "name": "dirt brothers"
+        },
+        "countries": [
+          {
+            "metrics": {
+              "impact": 62,
+              "count": 1,
+              "valuation_usd": 1.0779693710122982,
+              "valuation_by_country": [
+                {
+                  "chile": 765
+                }
+              ],
+              "impressions": 674,
+              "valuation": 765
+            },
+            "id": 1,
+            "name": "chile"
+          }
+        ],
+        "devices": [
+          {
+            "metrics": {
+              "impact": 62,
+              "count": 1,
+              "valuation_usd": 1.0779693710122982,
+              "valuation_by_country": [
+                {
+                  "chile": 765
+                }
+              ],
+              "impressions": 674,
+              "valuation": 765
+            },
+            "id": 1,
+            "name": "desktop"
+          }
+        ],
+        "metrics": {
+          "impact": 62,
+          "count": 1,
+          "valuation_usd": 1.0779693710122982,
+          "valuation_by_country": [
+            {
+              "chile": 765
+            }
+          ],
+          "impressions": 674,
+          "valuation": 765
+        },
+        "websites": [
+          {
+            "metrics": {
+              "impact": 62,
+              "count": 1,
+              "valuation_usd": 1.0779693710122982,
+              "valuation_by_country": [
+                {
+                  "chile": 765
+                }
+              ],
+              "impressions": 674,
+              "valuation": 765
+            },
+            "domain": "diarioconcepcion.cl",
+            "id": 4250
+          }
+        ],
+        "sold_by": [
+          {
+            "metrics": {
+              "impact": 62,
+              "count": 1,
+              "valuation_usd": 1.0779693710122982,
+              "valuation_by_country": [
+                {
+                  "chile": 765
+                }
+              ],
+              "impressions": 674,
+              "valuation": 765
+            },
+            "id": "google",
+            "name": "google"
+          }
+        ],
+        "preview": {
+          "ad_measurements": {
+            "width": 160,
+            "height": 600
+          },
+          "ad_file": {
+            "name": "https://ads.admetricks.com/banner_869179d3f518e157cc726586f752bc49.jpg"
+          }
+        },
+        "id": 7798600,
+        "ad_types": [
+          {
+            "metrics": {
+              "impact": 62,
+              "count": 1,
+              "valuation_usd": 1.0779693710122982,
+              "valuation_by_country": [
+                {
+                  "chile": 765
+                }
+              ],
+              "impressions": 674,
+              "valuation": 765
+            },
+            "id": 1,
+            "name": "display"
+          }
+        ]
+      },
+      {
+        "landing_page": "yerka.cl/products/chapa-yerka",
+        "description": null,
+        "ad_format": {
+          "id": 154,
+          "name": "brand-day"
+        },
+        "title": "Chapa Yerka– Yerka Bikes Chile",
+        "date_range": {
+          "start": "2020-11-24T00:48:55.000Z",
+          "end": "2020-11-24T00:48:55.000Z"
+        },
+        "industry": {
+          "id": 204,
+          "name": "deportes y tiempo libre - artículos deportivos"
+        },
+        "brand": {
+          "id": 120972,
+          "name": "yerka"
+        },
+        "countries": [
+          {
+            "metrics": {
+              "impact": 22,
+              "count": 1,
+              "valuation_usd": 0.12681992600144684,
+              "valuation_by_country": [
+                {
+                  "chile": 90
+                }
+              ],
+              "impressions": 79,
+              "valuation": 90
+            },
+            "id": 1,
+            "name": "chile"
+          }
+        ],
+        "devices": [
+          {
+            "metrics": {
+              "impact": 22,
+              "count": 1,
+              "valuation_usd": 0.12681992600144684,
+              "valuation_by_country": [
+                {
+                  "chile": 90
+                }
+              ],
+              "impressions": 79,
+              "valuation": 90
+            },
+            "id": 1,
+            "name": "desktop"
+          }
+        ],
+        "metrics": {
+          "impact": 22,
+          "count": 1,
+          "valuation_usd": 0.12681992600144684,
+          "valuation_by_country": [
+            {
+              "chile": 90
+            }
+          ],
+          "impressions": 79,
+          "valuation": 90
+        },
+        "websites": [
+          {
+            "metrics": {
+              "impact": 22,
+              "count": 1,
+              "valuation_usd": 0.12681992600144684,
+              "valuation_by_country": [
+                {
+                  "chile": 90
+                }
+              ],
+              "impressions": 79,
+              "valuation": 90
+            },
+            "domain": "aplicaciones.info",
+            "id": 386
+          }
+        ],
+        "sold_by": [
+          {
+            "metrics": {
+              "impact": 22,
+              "count": 1,
+              "valuation_usd": 0.12681992600144684,
+              "valuation_by_country": [
+                {
+                  "chile": 90
+                }
+              ],
+              "impressions": 79,
+              "valuation": 90
+            },
+            "id": "google",
+            "name": "google"
+          }
+        ],
+        "preview": {
+          "ad_measurements": {
+            "width": 970,
+            "height": 300
+          },
+          "ad_file": {
+            "name": "https://ads.admetricks.com/banner_cee4bae399a44001dde42e6fecc48886.jpg"
+          }
+        },
+        "id": 7799653,
+        "ad_types": [
+          {
+            "metrics": {
+              "impact": 22,
+              "count": 1,
+              "valuation_usd": 0.12681992600144684,
+              "valuation_by_country": [
+                {
+                  "chile": 90
+                }
+              ],
+              "impressions": 79,
+              "valuation": 90
+            },
+            "id": 1,
+            "name": "display"
+          }
+        ]
       }
     ],
     "websites": [
@@ -421,7 +763,7 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
         "metrics": {
           "impact": 8152,
           "count": 1,
-          "valuation_usd": 54.44819822133432,
+          "valuation_usd": 53.775875955480174,
           "valuation_by_country": [
             {
               "chile": 38163
@@ -432,6 +774,54 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
         },
         "domain": "clarin.com",
         "id": 365
+      },
+      {
+        "metrics": {
+          "impact": 62,
+          "count": 1,
+          "valuation_usd": 1.0779693710122982,
+          "valuation_by_country": [
+            {
+              "chile": 765
+            }
+          ],
+          "impressions": 674,
+          "valuation": 765
+        },
+        "domain": "diarioconcepcion.cl",
+        "id": 4250
+      },
+      {
+        "metrics": {
+          "impact": 22,
+          "count": 1,
+          "valuation_usd": 0.12681992600144684,
+          "valuation_by_country": [
+            {
+              "chile": 90
+            }
+          ],
+          "impressions": 79,
+          "valuation": 90
+        },
+        "domain": "aplicaciones.info",
+        "id": 386
+      },
+      {
+        "metrics": {
+          "impact": 5,
+          "count": 1,
+          "valuation_usd": 0.04509152924495887,
+          "valuation_by_country": [
+            {
+              "chile": 32
+            }
+          ],
+          "impressions": 28,
+          "valuation": 32
+        },
+        "domain": "bluradio.com",
+        "id": 1276
       }
     ],
     "brands_by_date": [
@@ -442,7 +832,7 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
             "metrics": {
               "impact": 8152,
               "count": 1,
-              "valuation_usd": 54.44819822133432,
+              "valuation_usd": 53.775875955480174,
               "valuation_by_country": [
                 {
                   "chile": 38163
@@ -456,6 +846,28 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
         ],
         "id": 141894,
         "name": "gympro"
+      },
+      {
+        "metrics_by_date": [
+          {
+            "date": "2020-11-23T00:00:00.000Z",
+            "metrics": {
+              "impact": 62,
+              "count": 1,
+              "valuation_usd": 1.0779693710122982,
+              "valuation_by_country": [
+                {
+                  "chile": 765
+                }
+              ],
+              "impressions": 674,
+              "valuation": 765
+            },
+            "date_int": 1606089600000
+          }
+        ],
+        "id": 342746,
+        "name": "dirt brothers"
       }
     ],
     "brands": [
@@ -463,7 +875,7 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
         "metrics": {
           "impact": 8152,
           "count": 1,
-          "valuation_usd": 54.44819822133432,
+          "valuation_usd": 53.775875955480174,
           "valuation_by_country": [
             {
               "chile": 38163
@@ -474,6 +886,104 @@ $response = Requests::post('https://clientela.admetricks.com/industry-report/', 
         },
         "id": 141894,
         "name": "gympro"
+      },
+      {
+        "metrics": {
+          "impact": 62,
+          "count": 1,
+          "valuation_usd": 1.0779693710122982,
+          "valuation_by_country": [
+            {
+              "chile": 765
+            }
+          ],
+          "impressions": 674,
+          "valuation": 765
+        },
+        "id": 342746,
+        "name": "dirt brothers"
+      }
+    ],
+    "brands_with_websites_by_date": [
+      {
+        "metrics": {
+          "impact": 8152,
+          "count": 1,
+          "valuation_usd": 53.775875955480174,
+          "valuation_by_country": [
+            {
+              "chile": 38163
+            }
+          ],
+          "impressions": 29387,
+          "valuation": 38163
+        },
+        "websites_by_date": [
+          {
+            "domain": "clarin.com",
+            "metrics_by_date": [
+              {
+                "date": "2020-11-23T00:00:00.000Z",
+                "metrics": {
+                  "impact": 8152,
+                  "count": 1,
+                  "valuation_usd": 53.775875955480174,
+                  "valuation_by_country": [
+                    {
+                      "chile": 38163
+                    }
+                  ],
+                  "impressions": 29387,
+                  "valuation": 38163
+                },
+                "date_int": 1606089600000
+              }
+            ],
+            "id": 365
+          }
+        ],
+        "id": 141894,
+        "name": "gympro"
+      },
+      {
+        "metrics": {
+          "impact": 62,
+          "count": 1,
+          "valuation_usd": 1.0779693710122982,
+          "valuation_by_country": [
+            {
+              "chile": 765
+            }
+          ],
+          "impressions": 674,
+          "valuation": 765
+        },
+        "websites_by_date": [
+          {
+            "domain": "diarioconcepcion.cl",
+            "metrics_by_date": [
+              {
+                "date": "2020-11-23T00:00:00.000Z",
+                "metrics": {
+                  "impact": 62,
+                  "count": 1,
+                  "valuation_usd": 1.0779693710122982,
+                  "valuation_by_country": [
+                    {
+                      "chile": 765
+                    }
+                  ],
+                  "impressions": 674,
+                  "valuation": 765
+                },
+                "date_int": 1606089600000
+              }
+            ],
+            "id": 4250
+          }
+        ],
+        "id": 342746,
+        "name": "dirt brothers"
       }
     ]
   }

--- a/source/includes/snippets/_post-reporte-de-marcas.md
+++ b/source/includes/snippets/_post-reporte-de-marcas.md
@@ -64,16 +64,16 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
     "industries": [
       {
         "metrics": {
-          "impact": 3839,
+          "impact": 3835,
           "count": 2,
-          "valuation_usd": 37.77565119216746,
+          "valuation_usd": 37.01591817924452,
           "valuation_by_country": [
             {
-              "chile": 26288
+              "chile": 26269
             }
           ],
-          "impressions": 19648,
-          "valuation": 26288
+          "impressions": 19622,
+          "valuation": 26269
         },
         "id": 221,
         "name": "energía - energía domestica"
@@ -86,16 +86,16 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
           {
             "date": "2020-12-29T00:00:00.000Z",
             "metrics": {
-              "impact": 3804,
+              "impact": 3798,
               "count": 1,
-              "valuation_usd": 37.039911181120985,
+              "valuation_usd": 36.25358951294694,
               "valuation_by_country": [
                 {
-                  "chile": 25776
+                  "chile": 25728
                 }
               ],
-              "impressions": 19470,
-              "valuation": 25776
+              "impressions": 19434,
+              "valuation": 25728
             },
             "date_int": 1609200000000
           }
@@ -108,16 +108,16 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
           {
             "date": "2020-12-29T00:00:00.000Z",
             "metrics": {
-              "impact": 35,
+              "impact": 37,
               "count": 1,
-              "valuation_usd": 0.7357400110464752,
+              "valuation_usd": 0.762328666297586,
               "valuation_by_country": [
                 {
-                  "chile": 512
+                  "chile": 541
                 }
               ],
-              "impressions": 178,
-              "valuation": 512
+              "impressions": 188,
+              "valuation": 541
             },
             "date_int": 1609200000000
           }
@@ -128,16 +128,16 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
     "ad_types": [
       {
         "metrics": {
-          "impact": 3839,
+          "impact": 3835,
           "count": 2,
-          "valuation_usd": 37.77565119216746,
+          "valuation_usd": 37.01591817924452,
           "valuation_by_country": [
             {
-              "chile": 26288
+              "chile": 26269
             }
           ],
-          "impressions": 19648,
-          "valuation": 26288
+          "impressions": 19622,
+          "valuation": 26269
         },
         "id": 1,
         "name": "display"
@@ -146,16 +146,16 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
     "countries": [
       {
         "metrics": {
-          "impact": 3839,
+          "impact": 3835,
           "count": 2,
-          "valuation_usd": 37.77565119216746,
+          "valuation_usd": 37.01591817924452,
           "valuation_by_country": [
             {
-              "chile": 26288
+              "chile": 26269
             }
           ],
-          "impressions": 19648,
-          "valuation": 26288
+          "impressions": 19622,
+          "valuation": 26269
         },
         "id": 1,
         "name": "chile"
@@ -168,32 +168,32 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
     "sold_by": [
       {
         "metrics": {
-          "impact": 3804,
+          "impact": 3798,
           "count": 1,
-          "valuation_usd": 37.039911181120985,
+          "valuation_usd": 36.25358951294694,
           "valuation_by_country": [
             {
-              "chile": 25776
+              "chile": 25728
             }
           ],
-          "impressions": 19470,
-          "valuation": 25776
+          "impressions": 19434,
+          "valuation": 25728
         },
         "id": "direct",
         "name": "direct"
       },
       {
         "metrics": {
-          "impact": 35,
+          "impact": 37,
           "count": 1,
-          "valuation_usd": 0.7357400110464752,
+          "valuation_usd": 0.762328666297586,
           "valuation_by_country": [
             {
-              "chile": 512
+              "chile": 541
             }
           ],
-          "impressions": 178,
-          "valuation": 512
+          "impressions": 188,
+          "valuation": 541
         },
         "id": "unknown",
         "name": "unknown"
@@ -202,16 +202,16 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
     "devices": [
       {
         "metrics": {
-          "impact": 3839,
+          "impact": 3835,
           "count": 2,
-          "valuation_usd": 37.77565119216746,
+          "valuation_usd": 37.01591817924452,
           "valuation_by_country": [
             {
-              "chile": 26288
+              "chile": 26269
             }
           ],
-          "impressions": 19648,
-          "valuation": 26288
+          "impressions": 19622,
+          "valuation": 26269
         },
         "id": 2,
         "name": "mobile"
@@ -222,10 +222,10 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
         {
           "date": "2020-12-29T00:00:00.000Z",
           "metrics": {
-            "impact": 3839,
-            "valuation_usd": 37.77565119216746,
-            "impressions": 19648,
-            "valuation": 26288
+            "impact": 3835,
+            "valuation_usd": 37.01591817924452,
+            "impressions": 19622,
+            "valuation": 26269
           },
           "date_int": 1609200000000
         }
@@ -233,10 +233,10 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
       "ad_types": [
         {
           "metrics": {
-            "impact": 3839,
-            "valuation_usd": 37.77565119216746,
-            "impressions": 19648,
-            "valuation": 26288
+            "impact": 3835,
+            "valuation_usd": 37.01591817924452,
+            "impressions": 19622,
+            "valuation": 26269
           },
           "id": 1,
           "name": "display"
@@ -245,36 +245,36 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
       "countries": [
         {
           "metrics": {
-            "impact": 3839,
-            "valuation_usd": 37.77565119216746,
-            "impressions": 19648,
-            "valuation": 26288
+            "impact": 3835,
+            "valuation_usd": 37.01591817924452,
+            "impressions": 19622,
+            "valuation": 26269
           },
           "id": 1,
           "name": "chile"
         }
       ],
-      "total_impressions": 19648,
-      "total_impact": 3839,
+      "total_impressions": 19622,
+      "total_impact": 3835,
       "devices": [
         {
           "metrics": {
-            "impact": 3839,
-            "valuation_usd": 37.77565119216746,
-            "impressions": 19648,
-            "valuation": 26288
+            "impact": 3835,
+            "valuation_usd": 37.01591817924452,
+            "impressions": 19622,
+            "valuation": 26269
           },
           "id": 2,
           "name": "mobile"
         }
       ],
-      "total_valuation_usd": 37.77565119216746,
+      "total_valuation_usd": 37.01591817924452,
       "position": {
         "first_scroll": 0,
         "second_scroll": 0,
         "third_or_more_scroll": 1
       },
-      "total_valuation": 26288
+      "total_valuation": 26269
     },
     "campaigns": [
       {
@@ -296,16 +296,16 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
         "countries": [
           {
             "metrics": {
-              "impact": 3839,
+              "impact": 3835,
               "count": 2,
-              "valuation_usd": 37.77565119216746,
+              "valuation_usd": 37.01591817924452,
               "valuation_by_country": [
                 {
-                  "chile": 26288
+                  "chile": 26269
                 }
               ],
-              "impressions": 19648,
-              "valuation": 26288
+              "impressions": 19622,
+              "valuation": 26269
             },
             "id": 1,
             "name": "chile"
@@ -314,62 +314,62 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
         "devices": [
           {
             "metrics": {
-              "impact": 3839,
+              "impact": 3835,
               "count": 2,
-              "valuation_usd": 37.77565119216746,
+              "valuation_usd": 37.01591817924452,
               "valuation_by_country": [
                 {
-                  "chile": 26288
+                  "chile": 26269
                 }
               ],
-              "impressions": 19648,
-              "valuation": 26288
+              "impressions": 19622,
+              "valuation": 26269
             },
             "id": 2,
             "name": "mobile"
           }
         ],
         "metrics": {
-          "impact": 3839,
+          "impact": 3835,
           "count": 2,
-          "valuation_usd": 37.77565119216746,
+          "valuation_usd": 37.01591817924452,
           "valuation_by_country": [
             {
-              "chile": 26288
+              "chile": 26269
             }
           ],
-          "impressions": 19648,
-          "valuation": 26288
+          "impressions": 19622,
+          "valuation": 26269
         },
         "websites": [
           {
             "metrics": {
-              "impact": 3804,
+              "impact": 3798,
               "count": 1,
-              "valuation_usd": 37.039911181120985,
+              "valuation_usd": 36.25358951294694,
               "valuation_by_country": [
                 {
-                  "chile": 25776
+                  "chile": 25728
                 }
               ],
-              "impressions": 19470,
-              "valuation": 25776
+              "impressions": 19434,
+              "valuation": 25728
             },
             "domain": "lacuarta.com",
             "id": 335
           },
           {
             "metrics": {
-              "impact": 35,
+              "impact": 37,
               "count": 1,
-              "valuation_usd": 0.7357400110464752,
+              "valuation_usd": 0.762328666297586,
               "valuation_by_country": [
                 {
-                  "chile": 512
+                  "chile": 541
                 }
               ],
-              "impressions": 178,
-              "valuation": 512
+              "impressions": 188,
+              "valuation": 541
             },
             "domain": "elnortero.cl",
             "id": 481
@@ -378,32 +378,32 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
         "sold_by": [
           {
             "metrics": {
-              "impact": 3804,
+              "impact": 3798,
               "count": 1,
-              "valuation_usd": 37.039911181120985,
+              "valuation_usd": 36.25358951294694,
               "valuation_by_country": [
                 {
-                  "chile": 25776
+                  "chile": 25728
                 }
               ],
-              "impressions": 19470,
-              "valuation": 25776
+              "impressions": 19434,
+              "valuation": 25728
             },
             "id": "direct",
             "name": "direct"
           },
           {
             "metrics": {
-              "impact": 35,
+              "impact": 37,
               "count": 1,
-              "valuation_usd": 0.7357400110464752,
+              "valuation_usd": 0.762328666297586,
               "valuation_by_country": [
                 {
-                  "chile": 512
+                  "chile": 541
                 }
               ],
-              "impressions": 178,
-              "valuation": 512
+              "impressions": 188,
+              "valuation": 541
             },
             "id": "unknown",
             "name": "unknown"
@@ -422,21 +422,91 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
         "ad_types": [
           {
             "metrics": {
-              "impact": 3839,
+              "impact": 3835,
               "count": 2,
-              "valuation_usd": 37.77565119216746,
+              "valuation_usd": 37.01591817924452,
               "valuation_by_country": [
                 {
-                  "chile": 26288
+                  "chile": 26269
                 }
               ],
-              "impressions": 19648,
-              "valuation": 26288
+              "impressions": 19622,
+              "valuation": 26269
             },
             "id": 1,
             "name": "display"
           }
         ]
+      }
+    ],
+    "campaigns_with_websites_by_date": [
+      {
+        "landing_page": "7852217",
+        "description": null,
+        "title": "Hito histórico para Enel: líder del Dow Jones Sustainability World Index de 2020",
+        "brand": {
+          "id": 8968,
+          "name": "enel"
+        },
+        "metrics": {
+          "impact": 3835,
+          "count": 2,
+          "valuation_usd": 37.01591817924452,
+          "valuation_by_country": [
+            {
+              "chile": 26269
+            }
+          ],
+          "impressions": 19622,
+          "valuation": 26269
+        },
+        "websites_by_date": [
+          {
+            "domain": "lacuarta.com",
+            "metrics_by_date": [
+              {
+                "date": "2020-12-29T00:00:00.000Z",
+                "metrics": {
+                  "impact": 3798,
+                  "count": 1,
+                  "valuation_usd": 36.25358951294694,
+                  "valuation_by_country": [
+                    {
+                      "chile": 25728
+                    }
+                  ],
+                  "impressions": 19434,
+                  "valuation": 25728
+                },
+                "date_int": 1609200000000
+              }
+            ],
+            "id": 335
+          },
+          {
+            "domain": "elnortero.cl",
+            "metrics_by_date": [
+              {
+                "date": "2020-12-29T00:00:00.000Z",
+                "metrics": {
+                  "impact": 37,
+                  "count": 1,
+                  "valuation_usd": 0.762328666297586,
+                  "valuation_by_country": [
+                    {
+                      "chile": 541
+                    }
+                  ],
+                  "impressions": 188,
+                  "valuation": 541
+                },
+                "date_int": 1609200000000
+              }
+            ],
+            "id": 481
+          }
+        ],
+        "id": 7852217
       }
     ],
     "campaigns_by_date": [
@@ -445,16 +515,16 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
           {
             "date": "2020-12-29T00:00:00.000Z",
             "metrics": {
-              "impact": 3839,
+              "impact": 3835,
               "count": 2,
-              "valuation_usd": 37.77565119216746,
+              "valuation_usd": 37.01591817924452,
               "valuation_by_country": [
                 {
-                  "chile": 26288
+                  "chile": 26269
                 }
               ],
-              "impressions": 19648,
-              "valuation": 26288
+              "impressions": 19622,
+              "valuation": 26269
             },
             "date_int": 1609200000000
           }
@@ -466,32 +536,32 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
     "websites": [
       {
         "metrics": {
-          "impact": 3804,
+          "impact": 3798,
           "count": 1,
-          "valuation_usd": 37.039911181120985,
+          "valuation_usd": 36.25358951294694,
           "valuation_by_country": [
             {
-              "chile": 25776
+              "chile": 25728
             }
           ],
-          "impressions": 19470,
-          "valuation": 25776
+          "impressions": 19434,
+          "valuation": 25728
         },
         "domain": "lacuarta.com",
         "id": 335
       },
       {
         "metrics": {
-          "impact": 35,
+          "impact": 37,
           "count": 1,
-          "valuation_usd": 0.7357400110464752,
+          "valuation_usd": 0.762328666297586,
           "valuation_by_country": [
             {
-              "chile": 512
+              "chile": 541
             }
           ],
-          "impressions": 178,
-          "valuation": 512
+          "impressions": 188,
+          "valuation": 541
         },
         "domain": "elnortero.cl",
         "id": 481
@@ -503,16 +573,16 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
           {
             "date": "2020-12-29T00:00:00.000Z",
             "metrics": {
-              "impact": 3839,
+              "impact": 3835,
               "count": 2,
-              "valuation_usd": 37.77565119216746,
+              "valuation_usd": 37.01591817924452,
               "valuation_by_country": [
                 {
-                  "chile": 26288
+                  "chile": 26269
                 }
               ],
-              "impressions": 19648,
-              "valuation": 26288
+              "impressions": 19622,
+              "valuation": 26269
             },
             "date_int": 1609200000000
           }
@@ -524,17 +594,81 @@ $response = Requests::post('https://clientela.admetricks.com/brands-report/', $h
     "brands": [
       {
         "metrics": {
-          "impact": 3839,
+          "impact": 3835,
           "count": 2,
-          "valuation_usd": 37.77565119216746,
+          "valuation_usd": 37.01591817924452,
           "valuation_by_country": [
             {
-              "chile": 26288
+              "chile": 26269
             }
           ],
-          "impressions": 19648,
-          "valuation": 26288
+          "impressions": 19622,
+          "valuation": 26269
         },
+        "id": 8968,
+        "name": "enel"
+      }
+    ],
+    "brands_with_websites_by_date": [
+      {
+        "metrics": {
+          "impact": 3835,
+          "count": 2,
+          "valuation_usd": 37.01591817924452,
+          "valuation_by_country": [
+            {
+              "chile": 26269
+            }
+          ],
+          "impressions": 19622,
+          "valuation": 26269
+        },
+        "websites_by_date": [
+          {
+            "domain": "lacuarta.com",
+            "metrics_by_date": [
+              {
+                "date": "2020-12-29T00:00:00.000Z",
+                "metrics": {
+                  "impact": 3798,
+                  "count": 1,
+                  "valuation_usd": 36.25358951294694,
+                  "valuation_by_country": [
+                    {
+                      "chile": 25728
+                    }
+                  ],
+                  "impressions": 19434,
+                  "valuation": 25728
+                },
+                "date_int": 1609200000000
+              }
+            ],
+            "id": 335
+          },
+          {
+            "domain": "elnortero.cl",
+            "metrics_by_date": [
+              {
+                "date": "2020-12-29T00:00:00.000Z",
+                "metrics": {
+                  "impact": 37,
+                  "count": 1,
+                  "valuation_usd": 0.762328666297586,
+                  "valuation_by_country": [
+                    {
+                      "chile": 541
+                    }
+                  ],
+                  "impressions": 188,
+                  "valuation": 541
+                },
+                "date_int": 1609200000000
+              }
+            ],
+            "id": 481
+          }
+        ],
         "id": 8968,
         "name": "enel"
       }


### PR DESCRIPTION
Export of result from implementation of https://github.com/admetricks/serverlessapi/pull/252

### How to test
[Reporte de marcas](https://stage.admetricks.com/docs/#reporte-de-marcas)
[Reporte de industria](https://stage.admetricks.com/docs/#reporte-de-mercado)

![image](https://user-images.githubusercontent.com/8508658/115030326-f8b6a580-9e94-11eb-94d0-dca4391c6663.png)
