### PR TITLE
✏️ fix(BaseReport): adjust group_by ranges defaults

### DIFF
--- a/source/includes/static/auto_groupby_date.md
+++ b/source/includes/static/auto_groupby_date.md
@@ -1,5 +1,5 @@
 | Rango de fechas | `group_by` resultante |
 | --------------- | --------------------- |
-| Hasta 90 días   | `day`                 |
-| Más de 90 días  | `week`                |
-| Más de un año   | `month`               |
+| Hasta 3 meses   | `day`                 |
+| Hasta 6 meses   | `week`                |
+| Más de 6 meses  | `month`               |


### PR DESCRIPTION
- Under 3 months: default to "day"
- Up to 6 months: default to "week"
- Over 6 months: default to "month"

**How to test**
[Stage](https://stage.admetricks.com/docs)